### PR TITLE
localStorageの位置を変更

### DIFF
--- a/next/src/pages/sign_out.tsx
+++ b/next/src/pages/sign_out.tsx
@@ -4,12 +4,12 @@ import { useEffect } from 'react'
 import { useUserState, useSnackbarState } from '@/hooks/useGlobalState'
 
 const SignOut: NextPage = () => {
-  localStorage.clear()
   const router = useRouter()
   const [, setUser] = useUserState()
   const [, setSnackbar] = useSnackbarState()
 
   useEffect(() => {
+    localStorage.clear()
     setUser({
       id: 0,
       name: '',


### PR DESCRIPTION
localStorageはクライアントサイドでしか使えない。
useEffect内はクライアントサイドでしか実行されないので、この中で呼び出すようにする